### PR TITLE
More changes for splitting exhaustiveness into a crate

### DIFF
--- a/compiler/rustc_mir_build/src/thir/pattern/deconstruct_pat.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/deconstruct_pat.rs
@@ -46,8 +46,7 @@ use self::Constructor::*;
 use self::SliceKind::*;
 
 use super::usefulness::{Context, PatCtxt, UsefulnessCtxt};
-
-use rustc_data_structures::captures::Captures;
+use super::Captures;
 
 use smallvec::{smallvec, SmallVec};
 use std::cell::Cell;
@@ -908,7 +907,7 @@ impl<'p, Cx: Context> Fields<'p, Cx> {
     }
 
     pub(super) fn singleton(ucx: &UsefulnessCtxt<'p, Cx>, field: DeconstructedPat<'p, Cx>) -> Self {
-        let field: &_ = ucx.pattern_arena.alloc(field);
+        let field = Cx::alloc_pat(ucx.pattern_arena, field);
         Fields { fields: std::slice::from_ref(field) }
     }
 
@@ -916,7 +915,7 @@ impl<'p, Cx: Context> Fields<'p, Cx> {
         ucx: &UsefulnessCtxt<'p, Cx>,
         fields: impl IntoIterator<Item = DeconstructedPat<'p, Cx>>,
     ) -> Self {
-        let fields: &[_] = ucx.pattern_arena.alloc_from_iter(fields);
+        let fields = Cx::alloc_pats_from_iter(ucx.pattern_arena, fields);
         Fields { fields }
     }
 
@@ -1056,8 +1055,8 @@ impl<'p, Cx: Context> DeconstructedPat<'p, Cx> {
                     VarLen(prefix, suffix) => {
                         let prefix = &self.fields.fields[..prefix];
                         let suffix = &self.fields.fields[self_slice.arity() - suffix..];
-                        let wildcard: &_ =
-                            ucx.pattern_arena.alloc(DeconstructedPat::wildcard(*inner_ty));
+                        let wildcard =
+                            Cx::alloc_pat(ucx.pattern_arena, DeconstructedPat::wildcard(*inner_ty));
                         let extra_wildcards = other_slice.arity() - self_slice.arity();
                         let extra_wildcards = (0..extra_wildcards).map(|_| wildcard);
                         prefix.iter().chain(extra_wildcards).chain(suffix).collect()

--- a/compiler/rustc_mir_build/src/thir/pattern/mod.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/mod.rs
@@ -11,6 +11,7 @@ use self::usefulness::UsefulnessCtxt;
 use crate::thir::util::UserAnnotatedTyHelpers;
 
 use rustc_apfloat::ieee::{DoubleS, IeeeFloat, SingleS};
+use rustc_arena::TypedArena;
 use rustc_data_structures::captures::Captures;
 use rustc_errors::struct_span_err;
 use rustc_hir as hir;
@@ -1242,6 +1243,25 @@ impl<'tcx> usefulness::Context for MatchCheckCtxt<'tcx> {
     fn span_bug(span: Self::Span, f: impl Fn() -> String) -> ! {
         let error = f();
         span_bug!(span, "{}", error)
+    }
+}
+
+impl<'p, 'tcx> usefulness::Alloc<'p, &'p Self> for MatchCheckCtxt<'tcx> {
+    type Cx = Self;
+    type PatternArena = TypedArena<DeconstructedPat<'p, Self>>;
+
+    fn alloc_pat(
+        arena: &'p Self::PatternArena,
+        pat: DeconstructedPat<'p, Self>,
+    ) -> &'p DeconstructedPat<'p, Self> {
+        arena.alloc(pat)
+    }
+
+    fn alloc_pats_from_iter(
+        arena: &'p Self::PatternArena,
+        pats: impl IntoIterator<Item = DeconstructedPat<'p, Self>>,
+    ) -> &'p [DeconstructedPat<'p, Self>] {
+        arena.alloc_from_iter(pats)
     }
 }
 

--- a/compiler/rustc_mir_build/src/thir/pattern/usefulness.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/usefulness.rs
@@ -378,9 +378,9 @@ pub(crate) trait Alloc<'p, L> {
     ) -> &'p [DeconstructedPat<'p, Self::Cx>];
 }
 
-crate struct UsefulnessCtxt<'p, Cx: Context> {
-    crate cx: Cx,
-    crate pattern_arena: &'p <Cx as Alloc<'p, &'p Cx>>::PatternArena,
+pub(crate) struct UsefulnessCtxt<'p, Cx: Context> {
+    pub(crate) cx: Cx,
+    pub(crate) pattern_arena: &'p <Cx as Alloc<'p, &'p Cx>>::PatternArena,
 }
 
 #[derive(Copy, Clone)]
@@ -735,7 +735,7 @@ enum ArmType {
 ///
 /// The final `Pair(Some(_), true)` is then the resulting witness.
 #[derive(Debug)]
-crate struct Witness<'p, Cx: Context>(Vec<DeconstructedPat<'p, Cx>>);
+pub(crate) struct Witness<'p, Cx: Context>(Vec<DeconstructedPat<'p, Cx>>);
 
 impl<'p, Cx: Context> Witness<'p, Cx> {
     /// Asserts that the witness contains a single pattern, and returns it.
@@ -934,34 +934,35 @@ fn is_useful<'p, Cx: Context>(
 
 /// The arm of a match expression.
 #[derive(Clone, Copy)]
-crate struct MatchArm<'p, Cx: Context> {
+pub(crate) struct MatchArm<'p, Cx: Context> {
     /// The pattern must have been lowered through `check_match::MatchVisitor::lower_pattern`.
-    crate pat: &'p DeconstructedPat<'p, Cx>,
-    crate hir_id: Cx::HirId,
-    crate has_guard: bool,
+    pub(crate) pat: &'p DeconstructedPat<'p, Cx>,
+    pub(crate) hir_id: Cx::HirId,
+    pub(crate) has_guard: bool,
 }
 
 /// Indicates whether or not a given arm is reachable.
 #[derive(Clone, Debug)]
-crate enum Reachability {
+pub(crate) enum Reachability {
     Reachable,
     Unreachable,
 }
 
 /// The output of checking a match for exhaustiveness and arm reachability.
-crate struct UsefulnessReport<'p, Cx: Context> {
+pub(crate) struct UsefulnessReport<'p, Cx: Context> {
     /// For each arm of the input, whether that arm is reachable after the arms above it.
-    crate arm_usefulness: Vec<(MatchArm<'p, Cx>, Reachability)>,
+    pub(crate) arm_usefulness: Vec<(MatchArm<'p, Cx>, Reachability)>,
     /// If the match is exhaustive, this is empty. If not, this contains witnesses for the lack of
     /// exhaustiveness.
-    crate non_exhaustiveness_witnesses: Vec<DeconstructedPat<'p, Cx>>,
+    pub(crate) non_exhaustiveness_witnesses: Vec<DeconstructedPat<'p, Cx>>,
     /// Reports any unreachable sub-or-patterns.
-    crate unreachable_subpatterns: Vec<(Cx::Span, Cx::HirId)>,
+    pub(crate) unreachable_subpatterns: Vec<(Cx::Span, Cx::HirId)>,
     /// Report when some variants of a `non_exhaustive` enum failed to be listed explicitly.
-    crate non_exhaustive_omitted_patterns:
+    pub(crate) non_exhaustive_omitted_patterns:
         Vec<(Cx::Ty, Cx::Span, Cx::HirId, Vec<DeconstructedPat<'p, Cx>>)>,
     /// Report likely incorrect range patterns (#63987)
-    crate overlapping_range_endpoints: Vec<(Cx::Span, Cx::HirId, Vec<DeconstructedPat<'p, Cx>>)>,
+    pub(crate) overlapping_range_endpoints:
+        Vec<(Cx::Span, Cx::HirId, Vec<DeconstructedPat<'p, Cx>>)>,
 }
 
 // Can't derive because it adds a bound on `Cx`.
@@ -982,7 +983,7 @@ impl<'p, Cx: Context> Default for UsefulnessReport<'p, Cx> {
 ///
 /// Note: the input patterns must have been lowered through
 /// `check_match::MatchVisitor::lower_pattern`.
-crate fn compute_match_usefulness<'p, Cx: Context>(
+pub(crate) fn compute_match_usefulness<'p, Cx: Context>(
     ucx: &UsefulnessCtxt<'p, Cx>,
     arms: &[MatchArm<'p, Cx>],
     scrut_hir_id: Cx::HirId,

--- a/compiler/rustc_mir_build/src/thir/pattern/usefulness.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/usefulness.rs
@@ -291,6 +291,12 @@ use std::fmt::Display;
 use std::fmt::{self, Debug};
 use std::iter::once;
 
+macro_rules! bug {
+    () => {
+        Cx::span_bug(None, format_args!("impossible case reached"))
+    };
+}
+
 /// Context for running the algorithm. This decouples the algorithm from specifics of types and the
 /// like.
 /// The `Copy` and `Debug` bounds are not actually used, but are needed because derived impls add
@@ -354,7 +360,7 @@ pub(crate) trait Context: Debug + Copy + for<'p> Alloc<'p, &'p Self, Cx = Self> 
         ctor: &Constructor<Self>,
     ) -> Vec<Self::Ty>;
 
-    fn span_bug(span: Self::Span, f: impl Fn() -> String) -> !;
+    fn span_bug(span: Option<Self::Span>, args: fmt::Arguments<'_>) -> !;
 }
 
 pub(crate) trait Alloc<'p, L> {


### PR DESCRIPTION
This threads `bug!` macro via `Context` trait and pattern allocations via an auxiliary trait.

The `Context` trait has received `for<'p> Alloc<'p, &'p Self, Cx = Self>` bound. I don't know if this is the best way to give users an ability to choose an arena implementation. I was striving to not clutter `Context` trait with `'p` lifetime.

_This PR targets `Nadrieril:split-exhaustiveness-into-crate` branch. Keeping it just for cherry picking commits that make sense to you_